### PR TITLE
Support activity stats updates in api

### DIFF
--- a/routescoop-api/app/controllers/Activities.scala
+++ b/routescoop-api/app/controllers/Activities.scala
@@ -1,14 +1,17 @@
 package controllers
 
 import javax.inject.{Inject, Singleton}
+import models.ActivityStats
 import modules.{AppConfig, NonBlockingContext}
 import services.{ActivityService, PowerAnalysisService}
 
 import com.typesafe.scalalogging.LazyLogging
-import play.api.libs.json.Json
+import play.api.libs.json.{JsError, Json}
 import play.api.mvc.{BaseController, ControllerComponents}
 
+import java.sql.{SQLException, SQLIntegrityConstraintViolationException}
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Success
 
 @Singleton
 class Activities @Inject()(
@@ -22,6 +25,20 @@ class Activities @Inject()(
     activityService.fetchActivities(userId, page, config.pageSize) map { summaries =>
       Ok(Json.toJson(summaries))
     }
+  }
+
+  def updateStats = Action.async(parse.json) { implicit request =>
+    request.body.validate[ActivityStats].fold(
+      errors => Future.successful(BadRequest(JsError.toJson(errors))),
+      stats => {
+        activityService.getActivity(stats.activityId) map {
+          case Some(_) =>
+            powerAnalysisService.updateActivityStats(stats)
+            NoContent
+          case None => BadRequest(s"Invalid activity stats ${Json.toJson(stats)}")
+        }
+      }
+    )
   }
 
   def getPowerDistribution(activityId: String) = Action.async { implicit request =>

--- a/routescoop-api/conf/routes
+++ b/routescoop-api/conf/routes
@@ -14,6 +14,8 @@ POST    /api/v1/users/:id/strava/tokens controllers.Tokens.createStravaToken(id:
 
 GET     /api/v1/users/:id/activities    controllers.Activities.list(id: String, page: Int ?= 1)
 
+PUT     /api/v1/activities/stats        controllers.Activities.updateStats
+
 GET     /api/v1/users/:id/fitness/:days controllers.Fitness.trainingLoad(id: String, days: Int)
 GET     /api/v1/users/:id/ramp/:days    controllers.Fitness.rampRate(id: String, days: Int)
 GET     /api/v1/users/:id/cp/:days      controllers.Fitness.criticalPower(id: String, days: Int, intervals: Seq[Int])


### PR DESCRIPTION
In order to make changes to the activity stats manually, a PUT endpoint is necessary for activity stats. This will enable a client application to send a payload to alter the stats generated for an activity in case one of the metrics cannot be generated. For example, if no power data, we need to manually assign the training load for the activity.