### PR TITLE
add capability to update training load score

### DIFF
--- a/routescoop-api/conf/application.conf
+++ b/routescoop-api/conf/application.conf
@@ -249,6 +249,8 @@ play.cache {
 #
 # libraryDependencies += filters
 #
+play.filters.enabled += "play.filters.cors.CORSFilter"
+
 play.filters {
   ## CORS filter configuration
   # https://www.playframework.com/documentation/latest/CorsFilter
@@ -262,7 +264,7 @@ play.filters {
     #pathPrefixes = ["/some/path", ...]
 
     # The allowed origins. If null, all origins are allowed.
-    #allowedOrigins = ["http://www.example.com"]
+    allowedOrigins = null
 
     # The allowed HTTP methods. If null, all methods are allowed
     #allowedHttpMethods = ["GET", "POST"]

--- a/routescoop-web/app/controllers/Rides.scala
+++ b/routescoop-web/app/controllers/Rides.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import config.AppConfig
 import javax.inject.{Inject, Singleton}
 import models._
 import services.{RideService, SettingsService}
@@ -20,8 +21,7 @@ class Rides @Inject()(
   stravaRefreshed: StravaTokenRefreshAction,
   rideService: RideService,
   settingsService: SettingsService,
-  ws: WSClient,
-  cache: SyncCacheApi,
+  config: AppConfig,
   val controllerComponents: ControllerComponents
 )(implicit ec: ExecutionContext) extends BaseController with I18nSupport {
 
@@ -65,7 +65,7 @@ class Rides @Inject()(
   def get(rideId: String) = authenticated.async { implicit request =>
     rideService.getRideDetails(rideId) map {
       case RideDetailsResultSuccess(ride) =>
-        Ok(views.html.rides.ride(ride))
+        Ok(views.html.rides.ride(ride, config))
       case RideDetailsResultError(_) =>
         Redirect(routes.Rides.index()).flashing("error" -> s"Failed to retrieve ride $rideId")
     }

--- a/routescoop-web/app/models/Ride.scala
+++ b/routescoop-web/app/models/Ride.scala
@@ -57,10 +57,13 @@ case class RideAnalysis(
   variabilityIndex: Double
 )
 
+object RideAnalysis {
+  implicit val analysisFormat = Json.format[RideAnalysis]
+}
+
 object Ride {
   implicit val locationReads = Json.reads[RideLocation]
   implicit val powerHrReads = Json.reads[RidePowerHr]
-  implicit val analysisReads = Json.reads[RideAnalysis]
   implicit val rideReads = Json.reads[Ride]
 }
 

--- a/routescoop-web/app/views/helper/base.scala.html
+++ b/routescoop-web/app/views/helper/base.scala.html
@@ -75,6 +75,7 @@
             </div>
         </div>
 
+        <script src="@routes.Assets.versioned("lib/vue/vue.js")" type="text/javascript"></script>
         <script src="@routes.Assets.versioned("lib/jquery/jquery.min.js")" type="text/javascript"></script>
         <script src="@routes.Assets.versioned("lib/bootstrap/js/bootstrap.min.js")" type="text/javascript"></script>
         <script src="@routes.Assets.versioned("lib/bootstrap-datepicker/js/bootstrap-datepicker.js")" type="text/javascript"></script>

--- a/routescoop-web/app/views/rides/ride.scala.html
+++ b/routescoop-web/app/views/rides/ride.scala.html
@@ -1,7 +1,37 @@
-@(ride: Ride)(implicit request: RequestHeader, messages: Messages, flash: Flash)
-@helper.base {
-    @Html("")
-} {
+@import play.api.libs.json.Json
+
+@import config.AppConfig
+
+@(ride: Ride, config: AppConfig)(implicit request: RequestHeader, messages: Messages, flash: Flash)
+
+@scripts = {
+    <script type="application/javascript">
+        const app = new Vue({
+            el: '#app',
+            data: {
+                analysis: @Html(Json.stringify(Json.toJson(ride.analysis.get))),
+                edit: false
+            },
+            methods: {
+                say: function(message) {
+                    alert(message)
+                },
+                postAnalysis: function() {
+                    const request = {
+                        method: "PUT",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify(this.analysis)
+                    };
+                    fetch(@Html("'" + config.baseApiUrl + "/activities/stats'"), request)
+                        .then(response => console.log(response))
+                        .then(_ => (this.edit = false))
+                }
+            }
+        })
+    </script>
+}
+
+@helper.base(scripts = scripts) {
 
     <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
         <h1 class="h2">@ride.name</h1>
@@ -18,11 +48,25 @@
             <p>Elevation gain @ride.totalElevationGain</p>
             <hr/>
             @ride.analysis.map { analysis =>
-                <p>Training load @analysis.stressScore</p>
-                <p>Intensity @analysis.intensityFactor</p>
-                <p>Average power @analysis.averagePower</p>
-                <p>Normalized power @analysis.normalizedPower</p>
-                <p>Variability index @analysis.variabilityIndex</p>
+                <div id="app">
+                    <template v-if="edit">
+                        <p>
+                            Training load <input v-model.number="analysis.stressScore">
+                            <button v-on:click="postAnalysis">Update</button>
+                            <a href="#" v-on:click="edit = !edit">Cancel</a>
+                        </p>
+                    </template>
+                    <template v-else>
+                        <p>
+                            Training load {{ analysis.stressScore }}
+                            <a href="#" v-on:click="edit = !edit">Edit</a>
+                        </p>
+                    </template>
+                    <p>Intensity @analysis.intensityFactor</p>
+                    <p>Average power @analysis.averagePower</p>
+                    <p>Normalized power @analysis.normalizedPower</p>
+                    <p>Variability index @analysis.variabilityIndex</p>
+                </div>
             }
             <hr>
             <p>Kilojoules @ride.powerHr.kilojoules</p>

--- a/routescoop-web/build.sbt
+++ b/routescoop-web/build.sbt
@@ -29,5 +29,6 @@ libraryDependencies ++= Seq(
   "org.webjars" % "chartjs" % "2.7.3",
   "org.webjars" % "jquery" % "3.3.1-1",
   "org.webjars" % "font-awesome" % "4.7.0",
-  "org.webjars" % "d3js" % "5.9.7"
+  "org.webjars" % "d3js" % "5.9.7",
+  "org.webjars" % "vue" % "2.6.12"
 )


### PR DESCRIPTION
Training load scores (TSS) will be zero when power meter data is not available. Other systems provide training load score estimation based on TRIMP (heartrate) and I wanted a way to manually update the training stress from the ride details page.